### PR TITLE
Invoke callback when server is stopped

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -44,9 +44,10 @@ function Server(root) {
       });
     },
 
-    stop: function() {
+    stop: function(cb) {
       httpServer.close(function() {
         console.log('Express stopped.');
+        if (cb) cb();
       });
     }
   }

--- a/test/server.js
+++ b/test/server.js
@@ -112,13 +112,24 @@ describe('server', function() {
   });
 
   describe('stop', function() {
-    it('should close the server', function() {
-      httpServer.close = sinon.spy();
+    beforeEach(function() {
+      httpServer.close = sinon.stub();
+    });
 
+    it('should close the server', function() {
       var server = Server();
       server.stop();
 
       expect(httpServer.close.called).to.be.true;
+    });
+
+    it('should invoke callback if provided', function() {
+      var server = Server();
+      var cb = sinon.spy();
+      httpServer.close.callsArg(0);
+      server.stop(cb);
+
+      expect(cb.called).to.be.true;
     });
   });
 });


### PR DESCRIPTION
When `endRunner` event is received, it is expected to return a promise and resolve it once the server is stopped (https://github.com/davidchin/gemini-express/blob/close_callback/lib/plugin.js#L27). However, the callback is never fired, therefore preventing Gemini from completing its promise chain when executing its runner. For example, when a critical error occurs, it is not logged as it never reaches the error handler at the end of the chain. This PR should fix this issue.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/saulis/gemini-express/2)

<!-- Reviewable:end -->
